### PR TITLE
Run jar on JRE version 17 or later

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ _The Ultimate Cycling Software_
 Download the latest executable jar file (gps-overlay-on-video.jar) from [here](https://github.com/peregin/gps-overlay-on-video/releases/latest/).
 It requires to have a `java` installation to run the application as follows:
 ```shell script
-java -jar gps-overlay-on-video.jar
+java --add-opens java.desktop/javax.swing.plaf.basic=ALL-UNNAMED -jar gps-overlay-on-video.jar
 ```
 There are other options to run the application see [How to run it](#how-to-run-it) section.
 

--- a/run.sh
+++ b/run.sh
@@ -2,4 +2,4 @@
 APP_FILE=/tmp/gps-overlay-on-video.jar
 echo "downloading latest version to $APP_FILE"
 curl -L https://github.com/peregin/gps-overlay-on-video/releases/latest/download/gps-overlay-on-video.jar --output $APP_FILE
-java --illegal-access=permit -jar $APP_FILE
+java --add-opens java.desktop/javax.swing.plaf.basic=ALL-UNNAMED -jar $APP_FILE


### PR DESCRIPTION
Adding `java` runtime options to run the downloaded `jar` in recent versions of JDK