### PR TITLE
Smooth calculating speed and elevation

### DIFF
--- a/src/main/scala/peregin/gpv/util/SeqUtil.scala
+++ b/src/main/scala/peregin/gpv/util/SeqUtil.scala
@@ -1,0 +1,35 @@
+package peregin.gpv.util
+
+import java.util.function.Predicate
+
+
+object SeqUtil {
+
+  /**
+   * Finds the latest value in the reversed sequence, i.e. the earliest value in original sequence.
+   *
+   * @param seq
+   *    sequence to search
+   * @param matcher
+   *    predicate to test values
+   * @tparam T
+   *    type of element
+   *
+   * @return
+   *    the leftmost value where this and following satisfy condition, or empty if no found.
+   */
+  def findReverseTill[T](seq: Seq[T], matcher: Predicate[T]): Option[T] = {
+    var found: Option[T] = None
+    val it = seq.reverseIterator
+    while (it.hasNext) {
+      val el: T = it.next()
+      if (matcher.test(el)) {
+        found = Some(el)
+      }
+      else {
+        return found
+      }
+    }
+    return found
+  }
+}


### PR DESCRIPTION
Speed now uses 3 seconds old point and next point.

Also updated elevation grade to use similar approach, considering only up to 5 seconds old points and using already calculated distance.
