### PR TITLE
Fix data interpolation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -129,7 +129,6 @@ libraryDependencies += "com.fasterxml.jackson.dataformat" % "jackson-dataformat-
 libraryDependencies += "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion
 libraryDependencies += "org.json4s" %% "json4s-native" % json4sVersion
 libraryDependencies += "org.json4s" %% "json4s-jackson" % json4sVersion
-libraryDependencies += "org.json4s" %% "json4s-jackson" % json4sVersion
 libraryDependencies += "ch.qos.logback" % "logback-classic" % logbackVersion
 libraryDependencies += "ch.qos.logback" % "logback-core" % logbackVersion
 libraryDependencies += "joda-time" % "joda-time" % jodaVersion

--- a/src/main/scala/peregin/gpv/format/GpsFormatter.scala
+++ b/src/main/scala/peregin/gpv/format/GpsFormatter.scala
@@ -32,7 +32,7 @@ object GpsFormatter {
     out += String.format("%02.0f'", minute)
     remain = 60*(remain - minute)
 
-    out += String.format("%07.4f\"", remain)
+    out += String.format("%04.1f\"", remain)
 
     return out;
   }

--- a/src/main/scala/peregin/gpv/gui/gauge/DateTimeGauge.scala
+++ b/src/main/scala/peregin/gpv/gui/gauge/DateTimeGauge.scala
@@ -4,11 +4,14 @@ import peregin.gpv.model.{InputValue, Sonda}
 
 import java.awt._
 import java.time.{LocalDateTime, ZoneId}
-import java.time.format.DateTimeFormatter
+import java.time.format.{DateTimeFormatter, DateTimeFormatterBuilder}
+import java.time.temporal.ChronoField
+import java.util.Locale
 
 
 class DateTimeGauge extends GaugePainter {
   val PADDING: Int = 5;
+  val TIME_FORMATTER: DateTimeFormatter = (new DateTimeFormatterBuilder).appendValue(ChronoField.HOUR_OF_DAY, 2).appendLiteral(':').appendValue(ChronoField.MINUTE_OF_HOUR, 2).appendLiteral(':').appendValue(ChronoField.SECOND_OF_MINUTE, 2).toFormatter(Locale.ROOT)
 
   var localTime: LocalDateTime = _;
   override def defaultInput: InputValue = null
@@ -21,8 +24,8 @@ class DateTimeGauge extends GaugePainter {
 
     // draw current time
     g.setFont(gaugeFont.deriveFont(Font.BOLD, (h * 3 / 16).toFloat))
-    val dateText = f"${DateTimeFormatter.ISO_LOCAL_DATE.format(localTime)}%s"
-    val timeText = f"${DateTimeFormatter.ISO_LOCAL_TIME.format(localTime)}%s"
+    val dateText = DateTimeFormatter.ISO_LOCAL_DATE.format(localTime)
+    val timeText = TIME_FORMATTER.format(localTime)
 
     val dateBounds = g.getFontMetrics().getStringBounds("9999-99-99 ", g)
     val timeBounds = g.getFontMetrics().getStringBounds("99:99:99 ", g)

--- a/src/main/scala/peregin/gpv/model/InputValue.scala
+++ b/src/main/scala/peregin/gpv/model/InputValue.scala
@@ -2,6 +2,7 @@ package peregin.gpv.model
 
 object InputValue {
 
+  def empty = new InputValue(0d, MinMax.empty)
   def zero = new InputValue(0d, MinMax.zero)
 }
 

--- a/src/main/scala/peregin/gpv/model/MinMax.scala
+++ b/src/main/scala/peregin/gpv/model/MinMax.scala
@@ -3,6 +3,7 @@ package peregin.gpv.model
 import MinMax._
 
 object MinMax {
+  def empty = new MinMax(0, 100)
   def zero = new MinMax(0, 0)
   def extreme = new MinMax(Double.MaxValue, Double.MinValue)
   def max(max: Double) = new MinMax(0, max)

--- a/src/main/scala/peregin/gpv/model/Sonda.scala
+++ b/src/main/scala/peregin/gpv/model/Sonda.scala
@@ -9,15 +9,15 @@ object Sonda {
 
   def zeroAt(t: DateTime): Sonda = new Sonda(t, InputValue.zero,
     new GeoPosition(0, 0),
-    InputValue.zero, InputValue.zero,
-    InputValue.zero, InputValue.zero, InputValue.zero,
+    InputValue.empty, InputValue.empty,
+    InputValue.empty, InputValue.empty, InputValue.empty,
     None, None, None, None
   )
 
   def sample(): Sonda = new Sonda(
     time = DateTime.now(), elapsedTime = InputValue.zero,
     location = new GeoPosition(47.366074, 8.541264), // Buerkliplatz, Zurich, Switzerland
-    elevation = InputValue(480, MinMax.max(640)), grade = InputValue.zero,
+    elevation = InputValue(480, MinMax.max(640)), grade = InputValue.empty,
     distance = InputValue(4, MinMax.max(12)), speed = InputValue(32, MinMax.max(61)),
     bearing = InputValue(90, MinMax.max(360)),
     cadence = Some(InputValue(81, MinMax.max(100))),

--- a/src/main/scala/peregin/gpv/util/SeqUtil.scala
+++ b/src/main/scala/peregin/gpv/util/SeqUtil.scala
@@ -1,6 +1,6 @@
 package peregin.gpv.util
 
-import java.util.function.Predicate
+import java.util.function.{Predicate}
 
 
 object SeqUtil {
@@ -32,4 +32,29 @@ object SeqUtil {
     }
     return found
   }
+
+  /**
+   * Returns the index with greatest value less than or equal to the given value, or -1 if there is no such key.
+   */
+  def floorIndex[K, T](seq: Seq[T], value: K, extractFunc: T => K, comparator: (K, K) => Int): Int = {
+    var ( b, e)  = ( 0, seq.size )
+    var found = -1
+    while (b < e) {
+      val m = b + (e - b) / 2
+      val c = extractFunc(seq(m))
+      val r = comparator(value, c)
+      if (r < 0) {
+        e = m
+      }
+      else {
+        found = m
+        b = m
+        if (b >= e - 1) {
+          return found
+        }
+      }
+    }
+    found
+  }
+
 }

--- a/src/test/scala/peregin/gpv/util/SeqUtilSpec.scala
+++ b/src/test/scala/peregin/gpv/util/SeqUtilSpec.scala
@@ -1,0 +1,43 @@
+package peregin.gpv.util
+
+import org.specs2.mutable.Specification
+
+
+/**
+ * Created by Zbynek Vyskovsky on 2024-07-26.
+ */
+class SeqUtilSpec extends Specification {
+
+  "floorIndex" should {
+    "first in even" in {
+      val r = SeqUtil.floorIndex(Seq(1, 2, 3, 4), 1, (el: Int) => el, (a: Int, b: Int) => a - b)
+      r mustEqual(0)
+    }
+
+    "first in odd" in {
+      val r = SeqUtil.floorIndex(Seq(1, 2, 3, 4, 5), 1, (el: Int) => el, (a: Int, b: Int) => a - b)
+      r mustEqual(0)
+    }
+
+    "last in even" in {
+      val r = SeqUtil.floorIndex(Seq(1, 2, 3, 4), 4, (el: Int) => el, (a: Int, b: Int) => a - b)
+      r mustEqual(3)
+    }
+
+    "last in odd" in {
+      val r = SeqUtil.floorIndex(Seq(1, 2, 3, 4, 5), 5, (el: Int) => el, (a: Int, b: Int) => a - b)
+      r mustEqual(4)
+    }
+
+    "lower only" in {
+      val r = SeqUtil.floorIndex(Seq(0, 1, 3, 4), 2, (el: Int) => el, (a: Int, b: Int) => a - b)
+      r mustEqual(1)
+    }
+
+    "repeated should return last" in {
+      val r = SeqUtil.floorIndex(Seq(0, 1, 1, 1, 3, 4), 2, (el: Int) => el, (a: Int, b: Int) => a - b)
+      r mustEqual(3)
+    }
+  }
+
+}


### PR DESCRIPTION
I noticed the interpolation actually did not work - the found next TrackPoint was typically before the progress, therefore it was always 0% or 100% between the points.  It seemed there was a bug in original function - didn't fix it as I'm not so familiar with Scala and used old school imperative solution instead :-D

Also:
- Fixes duplicity introduced in previous PR.
- Formats only one decimal in location seconds.
