### PR TITLE
Fix tests to match new algorithms

### DIFF
--- a/src/main/scala/peregin/gpv/model/Telemetry.scala
+++ b/src/main/scala/peregin/gpv/model/Telemetry.scala
@@ -100,7 +100,7 @@ case class Telemetry(track: Seq[TrackPoint]) extends Timed with Logging {
       point.extension.power.foreach(powerBoundary.sample)
       if (i < n - 1) {
         val nextPoint = track(i + 1)
-        val prevPoints = track.slice(0.max(i - 10), 0.max(i - 1))
+        val prevPoints = track.slice(0.max(i - 10), 0.max(i))
         point.analyze(nextPoint, prevPoints)
         speedBoundary.sample(point.speed)
         bearingBoundary.sample(point.bearing)
@@ -220,7 +220,7 @@ case class Telemetry(track: Seq[TrackPoint]) extends Timed with Logging {
   private def interpolate(progress: Double, left: TrackPoint, right: TrackPoint): Sonda = {
     val t = new DateTime(interpolate(progress, left.time.getMillis, right.time.getMillis).toLong)
     val elevation = interpolate(progress, left.elevation, right.elevation)
-    val distance = left.distance + interpolate(progress, 0, left.segment)
+    val distance = interpolate(progress, left.distance, right.distance)
     val location = new GeoPosition(
       interpolate(progress, left.position.getLatitude, right.position.getLatitude),
       interpolate(progress, left.position.getLongitude, right.position.getLongitude)

--- a/src/test/scala/peregin/gpv/GpsFormatterSpec.scala
+++ b/src/test/scala/peregin/gpv/GpsFormatterSpec.scala
@@ -11,25 +11,25 @@ class GpsFormatterSpec extends Specification with ScalaCheck {
 
   "formatLon" should {
     "positive as East" in {
-      GpsFormatter.formatLon(18.0697738) === "E018°04'11.1857\""
+      GpsFormatter.formatLon(18.0697738) === "E018°04'11.2\""
     }
     "zero with padding" in {
-      GpsFormatter.formatLon(0) === "E000°00'00.0000\""
+      GpsFormatter.formatLon(0) === "E000°00'00.0\""
     }
     "negative as West" in {
-      GpsFormatter.formatLon(-18.0697738) === "W018°04'11.1857\""
+      GpsFormatter.formatLon(-18.0697738) === "W018°04'11.2\""
     }
   }
 
   "formatLat" should {
     "positive as North" in {
-      GpsFormatter.formatLat(49.6930908) === "N049°41'35.1269\""
+      GpsFormatter.formatLat(49.6930908) === "N049°41'35.1\""
     }
     "zero with padding" in {
-      GpsFormatter.formatLat(0) === "N000°00'00.0000\""
+      GpsFormatter.formatLat(0) === "N000°00'00.0\""
     }
     "positive as South" in {
-      GpsFormatter.formatLat(-49.6930908) === "S049°41'35.1269\""
+      GpsFormatter.formatLat(-49.6930908) === "S049°41'35.1\""
     }
   }
 }

--- a/src/test/scala/peregin/gpv/model/TelemetrySpec.scala
+++ b/src/test/scala/peregin/gpv/model/TelemetrySpec.scala
@@ -71,8 +71,8 @@ class TelemetrySpec extends Specification with Logging {
       telemetry.latitudeBoundary === MinMax(47.231995, 47.310311)
       telemetry.longitudeBoundary === MinMax(8.504216, 8.566166)
       telemetry.totalDistance === 25.969048381307253
-      telemetry.speedBoundary must beCloseTo(MinMax(0.07879420148031871, 86.28724568098714), 6.significantFigures)
-      telemetry.gradeBoundary must beCloseTo(MinMax(-35.5112900107015, 38.58484806897635), 6.significantFigures)
+      telemetry.speedBoundary must beCloseTo(MinMax(0.09112632073465615, 59.243948420666825), 6.significantFigures)
+      telemetry.gradeBoundary must beCloseTo(MinMax(-98.30704744911834, 83.0031026111796), 6.significantFigures)
       telemetry.cadenceBoundary === MinMax(0, 120)
       telemetry.temperatureBoundary === MinMax(6, 14)
       telemetry.heartRateBoundary === MinMax(104, 175)
@@ -88,7 +88,7 @@ class TelemetrySpec extends Specification with Logging {
     "find outliers" in {
       val outliers = telemetry.track.count(_.grade > 30)
       log.info(s"found $outliers outliers out of ${telemetry.track.size}")
-      outliers === 9
+      outliers === 24
     }
   }
 
@@ -100,9 +100,9 @@ class TelemetrySpec extends Specification with Logging {
     "calculate min max" in {
       telemetry.track must haveSize(9558)
       telemetry.elevationBoundary === MinMax(886.0, 2763.0)
-      telemetry.speedBoundary.max must beCloseTo(85.56435201871793 within 6.significantFigures)
+      telemetry.speedBoundary.max must beCloseTo(72.5273477593884 within 6.significantFigures)
       telemetry.totalDistance must beCloseTo(63.23256444282121 within 6.significantFigures)
-      telemetry.gradeBoundary must beCloseTo(MinMax(-38.71463504215173, 114.48149716420424), 6.significantFigures)
+      telemetry.gradeBoundary must beCloseTo(MinMax(-38.92201022163103, 45.4785638380317), 6.significantFigures)
     }
   }
 
@@ -112,7 +112,7 @@ class TelemetrySpec extends Specification with Logging {
     "calculate min max" in {
       telemetry.track must haveSize(1009)
       telemetry.elevationBoundary === MinMax(442.0, 447.0)
-      telemetry.speedBoundary.max must beCloseTo(23.656438316953857 within 6.significantFigures)
+      telemetry.speedBoundary.max must beCloseTo(21.99203340260487 within 6.significantFigures)
       telemetry.totalDistance must beCloseTo(4.234620202017025 within 6.significantFigures)
     }
   }
@@ -122,10 +122,13 @@ class TelemetrySpec extends Specification with Logging {
 
     "calculate min max" in {
       telemetry.track must haveSize(674)
+//      System.out.println(telemetry.track.map(tp =>
+//        "" + tp.time + "\t" + tp.distance + "\t" + tp.elevation + "\t" + tp.grade + "\t" + tp.speed
+//      ))
       telemetry.elevationBoundary === MinMax(452.6, 513.2)
-      telemetry.speedBoundary.max must beCloseTo(33.471772761781544 within 6.significantFigures)
+      telemetry.speedBoundary.max must beCloseTo(31.164721940020353 within 6.significantFigures)
       telemetry.totalDistance must beCloseTo(12.492226904069824 within 6.significantFigures)
-      telemetry.gradeBoundary must beCloseTo(MinMax(-6.504534982064397, 11.890875118231593), 6.significantFigures)
+      telemetry.gradeBoundary must beCloseTo(MinMax(-17.133382884329485, 20.26883697227365), 6.significantFigures)
     }
   }
 


### PR DESCRIPTION
One bugfix - prevPoints didn't include the immediately preceding previous point.

Distance is interpolated on difference between distance instead of segment, as the interpolation may happen on the same single point.

The constants in tests were adjusted to match new smoothing algorithm.  Sometimes it's significant as the sample data are often recorded 3-5 seconds and new algorithm looks up to 9 seconds instead of previously 9 points.
