### PR TITLE
Use geographical distance to scale the MapGauge longitude

### DIFF
--- a/src/main/scala/peregin/gpv/model/MinMax.scala
+++ b/src/main/scala/peregin/gpv/model/MinMax.scala
@@ -34,7 +34,7 @@ case class MinMax(var min: Double, var max: Double) {
 
   def sample(sample: Double): Unit = {
     if (sample < min) min = sample
-    else if (sample > max) max = sample
+    if (sample > max) max = sample
   }
 
   def mean: Double = (max + min) / 2

--- a/src/main/scala/peregin/gpv/model/Telemetry.scala
+++ b/src/main/scala/peregin/gpv/model/Telemetry.scala
@@ -56,8 +56,12 @@ object Telemetry extends Timed with Logging {
     // Important: points are stored in a <b>Vector</b>, allows to efficiently access an element at an arbitrary position
     // and retrieving the size is O(1)
 
-    log.info(s"found ${points.size} track points")
-    val data = new Telemetry(points)
+    loadWith(points)
+  }
+
+  def loadWith(track: Seq[TrackPoint]): Telemetry = {
+    log.info(s"found ${track.size} track points")
+    val data = new Telemetry(track)
     data.analyze()
     log.info(f"elevation boundary: ${data.elevationBoundary}, max speed: ${data.speedBoundary.max}%.02f")
     data

--- a/src/test/scala/peregin/gpv/gui/gauge/MapGaugeSpec.scala
+++ b/src/test/scala/peregin/gpv/gui/gauge/MapGaugeSpec.scala
@@ -1,0 +1,130 @@
+package peregin.gpv.gui.gauge
+
+import org.jdesktop.swingx.mapviewer.GeoPosition
+import org.joda.time.DateTime
+import org.specs2.mutable.Specification
+import peregin.gpv.model.{GarminExtension, Telemetry, TrackPoint}
+
+import scala.collection.mutable.ArrayBuffer
+
+class MapGaugeSpec extends Specification {
+  stopOnFail
+
+  "crossing equator" should {
+    val mapGauge: MapGauge = new MapGauge()
+    mapGauge.telemetry = buildTelemetry(
+      -80, -80,
+      +80, +80,
+    )
+
+    "scaleLongitude is 1" in {
+      mapGauge.scaleLongitude must beCloseTo(1.0 within 6.significantFigures)
+    }
+    "screenPositions are even" in {
+      mapGauge.latitudeToScreen(-40, 10) must beCloseTo(400, 1)
+      mapGauge.longitudeToScreen(-40, 10) must beCloseTo(400, 1)
+    }
+  }
+
+  "low latitude" should {
+    val mapGauge: MapGauge = new MapGauge()
+    mapGauge.telemetry = buildTelemetry(
+      +10, -80,
+      +80, +80,
+    )
+
+    "scaleLongitude is high" in {
+      mapGauge.scaleLongitude must beCloseTo(0.98480775301 within 6.significantFigures)
+    }
+
+    "screenPositions are lightly skewed" in {
+      mapGauge.latitudeToScreen(45, 10) must beCloseTo(350, 1)
+      mapGauge.longitudeToScreen(-40, 10) must beCloseTo(393, 1)
+    }
+  }
+
+  "pole latitude" should {
+    val mapGauge: MapGauge = new MapGauge()
+    mapGauge.telemetry = buildTelemetry(
+      +80, 80,
+      +88, 88,
+    )
+
+    "scaleLongitude is low" in {
+      mapGauge.scaleLongitude must beCloseTo(0.17364817766 within 6.significantFigures)
+    }
+
+    "screenPositions are heavily skewed" in {
+      mapGauge.latitudeToScreen(82, 125) must beCloseTo(250, 1)
+      mapGauge.longitudeToScreen(82, 125) must beCloseTo(43, 1)
+    }
+  }
+
+  "constant longitude" should {
+    val mapGauge: MapGauge = new MapGauge()
+    mapGauge.telemetry = buildTelemetry(
+      +0, 10,
+      +10, 10,
+    )
+
+    "does not crash" in {
+      mapGauge.latitudeToScreen(5, 1) must beCloseTo(0, 1000)
+      mapGauge.longitudeToScreen(10, 1) must beCloseTo(0, 1000)
+    }
+  }
+
+  "constant latitude" should {
+    val mapGauge: MapGauge = new MapGauge()
+    mapGauge.telemetry = buildTelemetry(
+      +0, 0,
+      +0, 10,
+    )
+
+    "does not crash" in {
+      mapGauge.latitudeToScreen(0, 1) must beCloseTo(0, 1000)
+      mapGauge.longitudeToScreen(5, 1) must beCloseTo(0, 1000)
+    }
+  }
+
+  "single point" should {
+    val mapGauge: MapGauge = new MapGauge()
+    mapGauge.telemetry = buildTelemetry(
+      +0, 0,
+    )
+
+    "does not crash" in {
+      mapGauge.latitudeToScreen(0, 1) must beCloseTo(0, 1000)
+      mapGauge.longitudeToScreen(5, 1) must beCloseTo(0, 1000)
+    }
+  }
+
+  "crossing longitude 180" should {
+    val mapGauge: MapGauge = new MapGauge()
+    mapGauge.telemetry = buildTelemetry(
+      +10, 170,
+      +30, -170,
+    )
+
+    "scaleLongitude is based on difference 20" in {
+      mapGauge.scaleLongitude must beCloseTo(0.98480775301 within 6.significantFigures)
+    }
+
+    "screenPositions are based on difference 20, 20" in {
+      mapGauge.latitudeToScreen(15, 50) must beCloseTo(250, 1)
+      mapGauge.longitudeToScreen(175, 50) must beCloseTo(246, 1)
+    }
+  }
+
+  private def buildTelemetry(positions: Double*): Telemetry = {
+    val telemetry: Telemetry = Telemetry.loadWith(buildTrack(positions: _*))
+    telemetry
+  }
+
+  private def buildTrack(positions: Double*): Seq[TrackPoint] = {
+    val tps: ArrayBuffer[TrackPoint] = new ArrayBuffer[TrackPoint];
+    for (i <- 0 until positions.length by 2) {
+      tps.addOne(TrackPoint(new GeoPosition(positions(i + 0), positions(i + 1)), 0, new DateTime(i * 1000L), GarminExtension.empty))
+    }
+    tps.toSeq
+  }
+}


### PR DESCRIPTION
Simply speaking, scale longitude by `cos(latitude)`, so the horizontal and vertical distance appear the same on the map.

It also fixes a bug in `MinMax.sample()` where only one of min/max was updated, though impact in real scenarios was very unlikely.

New change solves 180 longitude crossing.  I want to review speed calculation but it seems correct.  However, `bearingTo` methods seem to be missing degree/radian conversion, I'll check that.
