### PR TITLE
Correctly interpolate circular units

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,7 @@ val xmlVersion = "2.3.0"
 val jodaVersion = "2.12.7"
 val swingVersion = "3.0.0"
 val javacvVersion = "1.5.10"
+val geotoolsVersion = "31.3"
 
 scalacOptions ++= List("-feature", "-deprecation", "-language:implicitConversions", "-language:reflectiveCalls")
 val macDockNameOpt = "-Xdock:name=\"GPS Overlay\""
@@ -43,7 +44,8 @@ javacOptions ++= Seq("-source", "17", "-target", "17")
 
 transitiveClassifiers in Global := Seq(Artifact.SourceClassifier)
 resolvers ++= Seq(
-  "Typesafe Repository" at "https://repo.typesafe.com/typesafe/releases/"
+  "Typesafe Repository" at "https://repo.typesafe.com/typesafe/releases/",
+  "GeoTools Repository" at "https://repo.osgeo.org/repository/release/",
 )
 
 assembly / mainClass := Some(entryPoint)
@@ -137,6 +139,7 @@ libraryDependencies += "joda-time" % "joda-time" % jodaVersion
 libraryDependencies += "org.joda" % "joda-convert" % "2.2.3"
 libraryDependencies += "org.apache.xmlgraphics" % "batik-transcoder" % batikVersion
 libraryDependencies += "com.google.guava" % "guava" % "33.2.1-jre"
+libraryDependencies += "org.geotools" % "gt-referencing" % geotoolsVersion exclude("javax.media", "jai_core")
 // deprecated from Java 9, needs to be added when
 libraryDependencies += "com.sun.activation" % "javax.activation" % "1.2.0"
 libraryDependencies += "org.specs2" %% "specs2-core" % specs2Version % "test"

--- a/src/test/scala/peregin/gpv/gui/gauge/MapGaugeSpec.scala
+++ b/src/test/scala/peregin/gpv/gui/gauge/MapGaugeSpec.scala
@@ -1,18 +1,15 @@
 package peregin.gpv.gui.gauge
 
-import org.jdesktop.swingx.mapviewer.GeoPosition
-import org.joda.time.DateTime
 import org.specs2.mutable.Specification
-import peregin.gpv.model.{GarminExtension, Telemetry, TrackPoint}
+import peregin.gpv.model.TelemetryTestUtil
 
-import scala.collection.mutable.ArrayBuffer
 
 class MapGaugeSpec extends Specification {
   stopOnFail
 
   "crossing equator" should {
     val mapGauge: MapGauge = new MapGauge()
-    mapGauge.telemetry = buildTelemetry(
+    mapGauge.telemetry = TelemetryTestUtil.buildTelemetry(
       -80, -80,
       +80, +80,
     )
@@ -28,7 +25,7 @@ class MapGaugeSpec extends Specification {
 
   "low latitude" should {
     val mapGauge: MapGauge = new MapGauge()
-    mapGauge.telemetry = buildTelemetry(
+    mapGauge.telemetry = TelemetryTestUtil.buildTelemetry(
       +10, -80,
       +80, +80,
     )
@@ -45,7 +42,7 @@ class MapGaugeSpec extends Specification {
 
   "pole latitude" should {
     val mapGauge: MapGauge = new MapGauge()
-    mapGauge.telemetry = buildTelemetry(
+    mapGauge.telemetry = TelemetryTestUtil.buildTelemetry(
       +80, 80,
       +88, 88,
     )
@@ -62,7 +59,7 @@ class MapGaugeSpec extends Specification {
 
   "constant longitude" should {
     val mapGauge: MapGauge = new MapGauge()
-    mapGauge.telemetry = buildTelemetry(
+    mapGauge.telemetry = TelemetryTestUtil.buildTelemetry(
       +0, 10,
       +10, 10,
     )
@@ -75,7 +72,7 @@ class MapGaugeSpec extends Specification {
 
   "constant latitude" should {
     val mapGauge: MapGauge = new MapGauge()
-    mapGauge.telemetry = buildTelemetry(
+    mapGauge.telemetry = TelemetryTestUtil.buildTelemetry(
       +0, 0,
       +0, 10,
     )
@@ -88,7 +85,7 @@ class MapGaugeSpec extends Specification {
 
   "single point" should {
     val mapGauge: MapGauge = new MapGauge()
-    mapGauge.telemetry = buildTelemetry(
+    mapGauge.telemetry = TelemetryTestUtil.buildTelemetry(
       +0, 0,
     )
 
@@ -100,7 +97,7 @@ class MapGaugeSpec extends Specification {
 
   "crossing longitude 180" should {
     val mapGauge: MapGauge = new MapGauge()
-    mapGauge.telemetry = buildTelemetry(
+    mapGauge.telemetry = TelemetryTestUtil.buildTelemetry(
       +10, 170,
       +30, -170,
     )
@@ -113,18 +110,5 @@ class MapGaugeSpec extends Specification {
       mapGauge.latitudeToScreen(15, 50) must beCloseTo(250, 1)
       mapGauge.longitudeToScreen(175, 50) must beCloseTo(246, 1)
     }
-  }
-
-  private def buildTelemetry(positions: Double*): Telemetry = {
-    val telemetry: Telemetry = Telemetry.loadWith(buildTrack(positions: _*))
-    telemetry
-  }
-
-  private def buildTrack(positions: Double*): Seq[TrackPoint] = {
-    val tps: ArrayBuffer[TrackPoint] = new ArrayBuffer[TrackPoint];
-    for (i <- 0 until positions.length by 2) {
-      tps.addOne(TrackPoint(new GeoPosition(positions(i + 0), positions(i + 1)), 0, new DateTime(i * 1000L), GarminExtension.empty))
-    }
-    tps.toSeq
   }
 }

--- a/src/test/scala/peregin/gpv/model/TelemetrySpec.scala
+++ b/src/test/scala/peregin/gpv/model/TelemetrySpec.scala
@@ -70,9 +70,9 @@ class TelemetrySpec extends Specification with Logging {
       telemetry.elevationBoundary === MinMax(446.2, 913.2)
       telemetry.latitudeBoundary === MinMax(47.231995, 47.310311)
       telemetry.longitudeBoundary === MinMax(8.504216, 8.566166)
-      telemetry.totalDistance === 25.969048381307253
-      telemetry.speedBoundary must beCloseTo(MinMax(0.09112632073465615, 59.243948420666825), 6.significantFigures)
-      telemetry.gradeBoundary must beCloseTo(MinMax(-98.30704744911834, 83.0031026111796), 6.significantFigures)
+      telemetry.totalDistance must beCloseTo(25.99097579963173, 6.significantFigures)
+      telemetry.speedBoundary must beCloseTo(MinMax(0.09113679892517283, 59.29239119878211), 6.significantFigures)
+      telemetry.gradeBoundary must beCloseTo(MinMax(-98.29878158370276, 82.98222101329881), 6.significantFigures)
       telemetry.cadenceBoundary === MinMax(0, 120)
       telemetry.temperatureBoundary === MinMax(6, 14)
       telemetry.heartRateBoundary === MinMax(104, 175)
@@ -80,8 +80,8 @@ class TelemetrySpec extends Specification with Logging {
 
     "validate first segment details" in {
       val first = telemetry.track(0)
-      first.segment === 0.005317274837638873
-      first.speed === 19.142189415499942
+      first.segment must beCloseTo(0.005316972239356387, 6.significantFigures)
+      first.speed === 19.14110006168299
       first.grade === 0d
     }
 
@@ -100,9 +100,9 @@ class TelemetrySpec extends Specification with Logging {
     "calculate min max" in {
       telemetry.track must haveSize(9558)
       telemetry.elevationBoundary === MinMax(886.0, 2763.0)
-      telemetry.speedBoundary.max must beCloseTo(72.5273477593884 within 6.significantFigures)
-      telemetry.totalDistance must beCloseTo(63.23256444282121 within 6.significantFigures)
-      telemetry.gradeBoundary must beCloseTo(MinMax(-38.92201022163103, 45.4785638380317), 6.significantFigures)
+      telemetry.speedBoundary.max must beCloseTo(72.51322702575003 within 6.significantFigures)
+      telemetry.totalDistance must beCloseTo(63.299609521916814 within 6.significantFigures)
+      telemetry.gradeBoundary must beCloseTo(MinMax(-38.887448712336536, 45.433599295298116), 6.significantFigures)
     }
   }
 
@@ -112,8 +112,8 @@ class TelemetrySpec extends Specification with Logging {
     "calculate min max" in {
       telemetry.track must haveSize(1009)
       telemetry.elevationBoundary === MinMax(442.0, 447.0)
-      telemetry.speedBoundary.max must beCloseTo(21.99203340260487 within 6.significantFigures)
-      telemetry.totalDistance must beCloseTo(4.234620202017025 within 6.significantFigures)
+      telemetry.speedBoundary.max must beCloseTo(22.05241079088749 within 6.significantFigures)
+      telemetry.totalDistance must beCloseTo(4.239035087385639 within 6.significantFigures)
     }
   }
 
@@ -126,9 +126,9 @@ class TelemetrySpec extends Specification with Logging {
 //        "" + tp.time + "\t" + tp.distance + "\t" + tp.elevation + "\t" + tp.grade + "\t" + tp.speed
 //      ))
       telemetry.elevationBoundary === MinMax(452.6, 513.2)
-      telemetry.speedBoundary.max must beCloseTo(31.164721940020353 within 6.significantFigures)
-      telemetry.totalDistance must beCloseTo(12.492226904069824 within 6.significantFigures)
-      telemetry.gradeBoundary must beCloseTo(MinMax(-17.133382884329485, 20.26883697227365), 6.significantFigures)
+      telemetry.speedBoundary.max must beCloseTo(31.159996504826278 within 6.significantFigures)
+      telemetry.totalDistance must beCloseTo(12.502044792928476 within 6.significantFigures)
+      telemetry.gradeBoundary must beCloseTo(MinMax(-17.13448107713459, 20.26293073285657), 6.significantFigures)
     }
   }
 
@@ -157,6 +157,46 @@ class TelemetrySpec extends Specification with Logging {
 
     "be parsed" in {
       telemetry.track must haveSize(179)
+    }
+  }
+
+  "bearing crosses north" should {
+    val telemetry = TelemetryTestUtil.buildTelemetry(
+      0, 10,
+      10, 10,
+      20, 11,
+      0, 10,
+      10, 10,
+      20, 9,
+    )
+
+    "interpolate cross to east" in {
+      val sonda = telemetry.sondaForRelativeTime(750).get
+      sonda.bearing.current must beCloseTo(4.0715656127530515 within 6.significantFigures)
+    }
+
+    "interpolate cross to west" in {
+      val sonda = telemetry.sondaForRelativeTime(3_750).get
+      sonda.bearing.current must beCloseTo(355.92843438724697 within 6.significantFigures)
+    }
+  }
+
+  "longitude crosses 180" should {
+    val telemetry = TelemetryTestUtil.buildTelemetry(
+      10, 170,
+      10, -170,
+      10, -170,
+      10, 170,
+    )
+
+    "interpolate cross to east" in {
+      val sonda = telemetry.sondaForRelativeTime(750).get
+      sonda.location.getLongitude must beCloseTo(-175.0 within 6.significantFigures)
+    }
+
+    "interpolate cross to west" in {
+      val sonda = telemetry.sondaForRelativeTime(2_750).get
+      sonda.location.getLongitude must beCloseTo(175.0 within 6.significantFigures)
     }
   }
 }

--- a/src/test/scala/peregin/gpv/model/TelemetryTestUtil.scala
+++ b/src/test/scala/peregin/gpv/model/TelemetryTestUtil.scala
@@ -1,0 +1,29 @@
+package peregin.gpv.model
+
+import org.jdesktop.swingx.mapviewer.GeoPosition
+import org.joda.time.DateTime
+
+import scala.collection.mutable.ArrayBuffer
+
+object TelemetryTestUtil {
+
+  /**
+   * Builds telemetry from lat,lon pairs.
+   */
+  def buildTelemetry(positions: Double*): Telemetry = {
+    val telemetry: Telemetry = Telemetry.loadWith(buildTrack(positions: _*))
+    telemetry
+  }
+
+  /**
+   * Builds TrackPoint sequence from lat,lon pairs.
+   */
+  def buildTrack(positions: Double*): Seq[TrackPoint] = {
+    val tps: ArrayBuffer[TrackPoint] = new ArrayBuffer[TrackPoint];
+    for (i <- 0 until positions.length by 2) {
+      tps.addOne(TrackPoint(new GeoPosition(positions(i + 0), positions(i + 1)), 0, new DateTime(i / 2 * 1000L), GarminExtension.empty))
+    }
+    tps.toSeq
+  }
+
+}


### PR DESCRIPTION
Correct interpolation of longitude and azimuth when crossing their boundaries.

It also uses geo-tools library for distance and azimuth calculation instead of own algorithm which I think was incorrect for azimuth (missing degrees to radians conversion).  Distance should be very slightly more precise too.

Based on previous PR due to test util dependencies.  To be rebased once #219 is merged.

