### PR TITLE
Allow negative times when GPX starts later in the video

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ java --add-opens java.desktop/javax.swing.plaf.basic=ALL-UNNAMED -jar gps-overla
 ```
 There are other options to run the application see [How to run it](#how-to-run-it) section.
 
-When running under windows make sure to use 32bit java JDK/JRE (due to bugs in the xuggle library when running in 64bit)
+When running make sure to use 64-bit java JDK/JRE (no video binaries included for 32-bit).
 
 ## Overview
 

--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,7 @@ run / fork := true
 
 val moreJavaOptions = Seq(
   //macDockNameOpt, // supported on MacOs only
+  "-Xmx1G",
   "--add-opens=java.desktop/javax.swing.plaf.basic=ALL-UNNAMED",
   "--add-opens=java.base/java.lang=ALL-UNNAMED",
   "--add-opens=java.base/java.util=ALL-UNNAMED",

--- a/src/main/scala/peregin/gpv/format/TimeFormatter.scala
+++ b/src/main/scala/peregin/gpv/format/TimeFormatter.scala
@@ -3,13 +3,14 @@ package peregin.gpv.format
 object TimeFormatter {
 
   def formatTime(timeSeconds: Long): String = {
-    var remain = timeSeconds
-    val seconds = timeSeconds % 60
+    var sign = math.signum(timeSeconds)
+    var remain = math.abs(timeSeconds)
+    val seconds = remain % 60
     remain /= 60
     val minutes = remain % 60
     remain /= 60
     val hours = remain
 
-    return String.format("% 3d:%02d:%02d", hours, minutes, seconds)
+    return String.format(if (sign < 0 && hours == 0) "  -%d:%02d:%02d" else "% 3d:%02d:%02d",  sign * hours, minutes, seconds)
   }
 }


### PR DESCRIPTION
The video starts with 00:00:00 and the first GPS record when the GPX is synced forward in the video (starts later than video).

This fix calculates absolute time and relative time based on the time sync value.  The timer is still set to 00:00:00 at first GPS point which is intentional and makes nice countdown towards the start of the race 😁.

There are still issues with some gauges not consuming `Option[]` values and therefore results in example values until GPS starts.  This requires bigger fix with passing `InputValue(Option[Double], MinMax)` instead of `Option[InputValue]` .  I'll consider fixing this - this would be general problem whenever some data is missing during the track.

Example: https://youtu.be/sU0WEkYdJ3s

Also fixed some outdated details in `README.md` and set Xmx to 1 GB (probably could be much less).
