### PR TITLE
Disable display when points or values are missing in GPX

### DIFF
--- a/src/main/scala/peregin/gpv/ConverterDialog.scala
+++ b/src/main/scala/peregin/gpv/ConverterDialog.scala
@@ -26,7 +26,7 @@ class ConverterDialog(setup: Setup, telemetry: Telemetry, template: TemplateEntr
 
   title = "Converter"
   modal = true
-  preferredSize = new Dimension(400, 440)
+  preferredSize = new Dimension(800, 600)
   // setup painter
   dash = template.dashboard
 

--- a/src/main/scala/peregin/gpv/gui/GaugeTestPanel.scala
+++ b/src/main/scala/peregin/gpv/gui/GaugeTestPanel.scala
@@ -29,7 +29,7 @@ class GaugeTestPanel[T <: GaugeComponent](factory: => T) extends MigPanel("ins 5
     override def stateChanged(e: ChangeEvent) = maxValueAdjusted()
   })
 
-  val slider = new JSlider(gauges(0).gaugePainter.defaultInput.boundary.min.toInt, gauges(0).gaugePainter.defaultInput.boundary.max.toInt, gauges(0).gaugePainter.defaultInput.current.toInt)
+  val slider = new JSlider(gauges(0).gaugePainter.defaultInput.boundary.min.toInt, gauges(0).gaugePainter.defaultInput.boundary.max.toInt, gauges(0).gaugePainter.defaultInput.current.getOrElse(0d).toInt)
   slider.addChangeListener(new ChangeListener {
     override def stateChanged(e: ChangeEvent) = curValueAdjusted()
   })
@@ -75,7 +75,7 @@ class GaugeTestPanel[T <: GaugeComponent](factory: => T) extends MigPanel("ins 5
   def updateGui(min: Int, max: Int, cur: Int): Unit = {
     status.text = s"Current Value $cur"
     gauges.foreach{g =>
-      g.gaugePainter.input = InputValue(cur, MinMax(min, max))
+      g.gaugePainter.input = InputValue(Some(cur), MinMax(min, max))
       g.repaint()
     }
   }

--- a/src/main/scala/peregin/gpv/gui/TemplatePanel.scala
+++ b/src/main/scala/peregin/gpv/gui/TemplatePanel.scala
@@ -97,7 +97,7 @@ class TemplatePanel(listener: Listener) extends MigPanel("ins 2", "[fill]", "[fi
         (entry.name, dashboard)
     }.toMap
 
-    private lazy val motorBikeSample = Sonda.sample().copy(speed = InputValue(181, MinMax.max(230)))
+    private lazy val motorBikeSample = Sonda.sample().copy(speed = InputValue(Some(181), MinMax.max(230)))
     private lazy val regularSample = Sonda.sample()
 
     override def paint(g: Graphics): Unit = {

--- a/src/main/scala/peregin/gpv/gui/dashboard/Dashboard.scala
+++ b/src/main/scala/peregin/gpv/gui/dashboard/Dashboard.scala
@@ -35,19 +35,19 @@ trait CyclingDashboard extends Dashboard {
     // paint gauges and charts
     speedGauge.paint(g, imageHeight, gaugeSize, gaugeSize, sonda)
     g.translate(gaugeSize, 0)
-    if (sonda.cadence.isDefined) {
+    if (sonda.cadence.current.isDefined) {
       cadenceGauge.paint(g, imageHeight, gaugeSize, gaugeSize, sonda)
       g.translate(gaugeSize, 0)
     }
 
     val gaugeSize2 = gaugeSize / 2
-    if (sonda.heartRate.isDefined) {
+    if (sonda.heartRate.current.isDefined) {
       g.translate(0, gaugeSize2)
       heartRateGauge.paint(g, imageHeight, gaugeSize2, gaugeSize2, sonda)
       g.translate(gaugeSize2, 0)
     }
-    if (sonda.power.isDefined) {
-      if (sonda.heartRate.isDefined) g.translate(-gaugeSize2, -gaugeSize2)
+    if (sonda.power.current.isDefined) {
+      if (sonda.heartRate.current.isDefined) g.translate(-gaugeSize2, -gaugeSize2)
       powerGauge.paint(g, imageHeight, gaugeSize2, gaugeSize2, sonda)
       g.translate(gaugeSize2, 0)
     }
@@ -75,7 +75,7 @@ trait SkiingDashboard extends Dashboard {
     g.translate(gaugeSize, 0)
 
     val gaugeSize2 = gaugeSize / 2
-    if (sonda.heartRate.isDefined) {
+    if (sonda.heartRate.current.isDefined) {
       g.translate(0, gaugeSize2)
       heartRateGauge.paint(g, imageHeight, gaugeSize2, gaugeSize2, sonda)
       g.translate(gaugeSize2, 0)
@@ -86,7 +86,7 @@ trait SkiingDashboard extends Dashboard {
 trait MotorBikingDashboard extends Dashboard {
 
   private val speedGauge = new RadialSpeedGauge {
-    override lazy val dummy: InputValue = InputValue(181, MinMax.max(230))
+    override lazy val dummy: InputValue = InputValue(Some(181), MinMax.max(230))
   }
   private val elevationChart = new ElevationChart {}
   private val heartRateGauge = new SvgHeartRateGauge {}
@@ -106,7 +106,7 @@ trait MotorBikingDashboard extends Dashboard {
     g.translate(gaugeSize, 0)
 
     val gaugeSize2 = gaugeSize / 2
-    if (sonda.heartRate.isDefined) {
+    if (sonda.heartRate.current.isDefined) {
       g.translate(0, gaugeSize2)
       heartRateGauge.paint(g, imageHeight, gaugeSize2, gaugeSize2, sonda)
       g.translate(gaugeSize2, 0)
@@ -137,7 +137,7 @@ trait SailingDashboard extends Dashboard {
 
 
     val gaugeSize2 = gaugeSize / 2
-    if (sonda.heartRate.isDefined) {
+    if (sonda.heartRate.current.isDefined) {
       g.translate(0, gaugeSize2)
       heartRateGauge.paint(g, imageHeight, gaugeSize2, gaugeSize2, sonda)
       g.translate(gaugeSize2, 0)

--- a/src/main/scala/peregin/gpv/gui/gauge/CadenceGauge.scala
+++ b/src/main/scala/peregin/gpv/gui/gauge/CadenceGauge.scala
@@ -8,9 +8,9 @@ import peregin.gpv.util.Trigo._
 
 class CadenceGauge extends GaugePainter {
 
-  lazy val dummy = InputValue(81, MinMax(0, 123))
+  lazy val dummy = InputValue(Some(81), MinMax(0, 123))
   override def defaultInput = dummy
-  override def sample(sonda: Sonda): Unit = {sonda.cadence.foreach(input = _)}
+  override def sample(sonda: Sonda): Unit = { input = sonda.cadence }
 
   override def paint(g: Graphics2D, devHeight: Int, w: Int, h: Int): Unit = {
     super.paint(g, devHeight, w, h)
@@ -25,7 +25,7 @@ class CadenceGauge extends GaugePainter {
     val start = 65
     val extent = 160
     var arc = new Arc2D.Double(x, y, dia, dia, start, extent, Arc2D.OPEN)
-    g.setStroke(new BasicStroke(strokeWidth, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 10.0f, null, 0.0f))
+    g.setStroke(new BasicStroke(strokeWidth.toFloat, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 10.0f, null, 0.0f))
     g.setColor(Color.black)
     g.draw(arc)
 
@@ -35,20 +35,22 @@ class CadenceGauge extends GaugePainter {
     y = (h - dia) / 2
     arc = new Arc2D.Double(x, y, dia, dia, start, extent, Arc2D.OPEN)
     g.setColor(Color.white)
-    val borderStroke = new BasicStroke(math.max(2, strokeWidth / 10))
+    val borderStroke = new BasicStroke(math.max(2, strokeWidth / 10).toFloat)
     g.setStroke(borderStroke)
     g.draw(arc)
 
-    // draw moving arc, showing the actual cadence
-    g.setColor(colorBasedOnInput)
-    val pdia = box - strokeWidth * 1.5
-    val px = (w - pdia) / 2
-    val py = (h - pdia) / 2
-    val pointerAngle = -135
-    val pointerLength = -input.current * extent / input.boundary.tenths
-    arc = new Arc2D.Double(px, py, pdia, pdia, pointerAngle, pointerLength, Arc2D.OPEN)
-    g.setStroke(new BasicStroke(math.max(2, strokeWidth / 4), BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 10.0f, null, 0.0f))
-    g.draw(arc)
+    if (input.current.isDefined) {
+      // draw moving arc, showing the actual cadence
+      g.setColor(colorBasedOnInput)
+      val pdia = box - strokeWidth * 1.5
+      val px = (w - pdia) / 2
+      val py = (h - pdia) / 2
+      val pointerAngle = -135
+      val pointerLength = -input.current.get * extent / input.boundary.tenths
+      arc = new Arc2D.Double(px, py, pdia, pdia, pointerAngle, pointerLength, Arc2D.OPEN)
+      g.setStroke(new BasicStroke(math.max(2, strokeWidth / 4), BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 10.0f, null, 0.0f))
+      g.draw(arc)
+    }
 
     // draw the the ticks and units
     g.setColor(Color.white)
@@ -84,11 +86,14 @@ class CadenceGauge extends GaugePainter {
     arc = new Arc2D.Double(x, y, dia, dia, start, extent, Arc2D.OPEN)
     g.draw(arc)
 
-    // draw current speed
-    g.setFont(gaugeFont.deriveFont(Font.BOLD, (longTickLength * 6).toFloat))
-    val text = f"${input.current}%2.0f"
-    val tb = g.getFontMetrics.getStringBounds(text, g)
-    textWidthShadow(g, text, (w - tb.getWidth) / 2, cy + box / 2 - tb.getHeight * 1.2)
+    if (input.current.isDefined) {
+      // draw current speed
+      g.setFont(gaugeFont.deriveFont(Font.BOLD, (longTickLength * 6).toFloat))
+      val text = f"${input.current.get}%2.0f"
+      val tb = g.getFontMetrics.getStringBounds(text, g)
+      textWidthShadow(g, text, (w - tb.getWidth) / 2, cy + box / 2 - tb.getHeight * 1.2)
+    }
+
     // draw unit
     g.setFont(gaugeFont.deriveFont(Font.BOLD, (longTickLength * 2).toFloat))
     val utext = "rpm"

--- a/src/main/scala/peregin/gpv/gui/gauge/DebugGauge.scala
+++ b/src/main/scala/peregin/gpv/gui/gauge/DebugGauge.scala
@@ -39,7 +39,7 @@ trait DebugGauge extends GaugePainter {
     // start drawing debug info
     var text = current.map(_.time).getOrElse(DateTime.now()).toString("HH:mm:ss.SSS")
     textWidthShadow(g, s"GPS Time: $text", tx, ty, Color.white)
-    text = printDuration(current.map(_.elapsedTime.current.toLong))
+    text = printDuration(current.map(_.elapsedTime.current.get.toLong))
     textWidthShadow(g, s"GPS Elapsed: $text", tx, ty + fh, Color.white)
     text = printDuration(current.map(_.videoProgress))
     textWidthShadow(g, s"VID Elapsed: $text", tx, ty + 2 * fh, Color.white)

--- a/src/main/scala/peregin/gpv/gui/gauge/DigitalElevationGauge.scala
+++ b/src/main/scala/peregin/gpv/gui/gauge/DigitalElevationGauge.scala
@@ -6,11 +6,11 @@ import peregin.gpv.util.UnitConverter
 
 class DigitalElevationGauge extends DigitalGauge {
 
-  lazy val dummy = InputValue(689, MinMax(432, 1252))
+  lazy val dummy = InputValue(Some(689), MinMax(432, 1252))
   override def defaultInput = dummy
   override def sample(sonda: Sonda): Unit = input = sonda.elevation
 
-  override def valueText() = f"${UnitConverter.elevation(input.current, units)}%2.0f"
+  override def valueText() = input.current.map(v => f"${UnitConverter.elevation(v, units)}%2.0f").getOrElse("")
 
   override def unitText() = UnitConverter.elevationUnits(units)
 }

--- a/src/main/scala/peregin/gpv/gui/gauge/DigitalSpeedGauge.scala
+++ b/src/main/scala/peregin/gpv/gui/gauge/DigitalSpeedGauge.scala
@@ -6,11 +6,11 @@ import peregin.gpv.util.UnitConverter
 
 class DigitalSpeedGauge extends DigitalGauge {
 
-  lazy val dummy = InputValue(23.52, MinMax(0, 71))
+  lazy val dummy = InputValue(Some(23.52), MinMax(0, 71))
   override def defaultInput: InputValue = dummy
   override def sample(sonda: Sonda): Unit = input = sonda.speed
 
-  override def valueText() = f"${UnitConverter.distance(input.current, units)}%2.1f"
+  override def valueText() = input.current.map(v => f"${UnitConverter.distance(v, units)}%2.1f").getOrElse("")
 
   override def unitText() = UnitConverter.distanceUnits(units)
 }

--- a/src/main/scala/peregin/gpv/gui/gauge/DistanceAndDurationGauge.scala
+++ b/src/main/scala/peregin/gpv/gui/gauge/DistanceAndDurationGauge.scala
@@ -27,7 +27,7 @@ class DistanceAndDurationGauge extends ChartPainter {
 
   override def sample(sonda: Sonda): Unit = {
     currentTime = sonda.time.toDate.toInstant
-    currentDistance = sonda.distance.current
+    currentDistance = sonda.distance.current.get
   }
 
   override def paint(g: Graphics2D, devHeight: Int, w: Int, h: Int): Unit = {

--- a/src/main/scala/peregin/gpv/gui/gauge/GaugePainter.scala
+++ b/src/main/scala/peregin/gpv/gui/gauge/GaugePainter.scala
@@ -10,7 +10,7 @@ import java.util.function.Consumer
 trait GaugePainter {
 
   lazy val gaugeFont = new Font("Verdana", Font.PLAIN, 12)
-  private var currentInput: Option[InputValue] = None
+  private var currentInput: InputValue = InputValue.empty
   private var debugging = false
   private var displayUnits: String = ""
 
@@ -40,8 +40,8 @@ trait GaugePainter {
   // each implementation should provide the default values used for testing or to show a sample in the gauges' list
   def defaultInput: InputValue
 
-  def input: InputValue = currentInput.getOrElse(defaultInput)
-  def input_= (v: InputValue): Unit = currentInput = Some(v)
+  def input: InputValue = currentInput
+  def input_= (v: InputValue): Unit = currentInput = v
 
   def debug: Boolean = debugging
   def debug_= (v: Boolean): Unit = debugging = v
@@ -60,10 +60,10 @@ trait GaugePainter {
   def drawShadowed(g: Graphics2D, devHeight: Int, consumer: Consumer[Graphics2D]): Unit = {
     // For 480, we want 2 pixels, for standard 1080, we want 3 pixels
     g.setColor(new Color(0, 0, 0, 128))
-    g.setStroke(new BasicStroke(shadowWidth(g, devHeight)))
+    g.setStroke(new BasicStroke(shadowWidth(g, devHeight).toFloat))
     consumer.accept(g)
     g.setColor(Color.yellow)
-    g.setStroke(new BasicStroke(lineWidth(g, devHeight)))
+    g.setStroke(new BasicStroke(lineWidth(g, devHeight).toFloat))
     consumer.accept(g)
   }
 

--- a/src/main/scala/peregin/gpv/gui/gauge/GradeGauge.scala
+++ b/src/main/scala/peregin/gpv/gui/gauge/GradeGauge.scala
@@ -8,7 +8,7 @@ import java.awt._
 class GradeGauge extends GaugePainter {
   var elevation: InputValue = _;
 
-  lazy val dummy: InputValue = InputValue(8.5, MinMax.max(100))
+  lazy val dummy: InputValue = InputValue(Some(8.5), MinMax.max(100))
   override def defaultInput: InputValue = dummy
   override def sample(sonda: Sonda): Unit = {
     input = sonda.grade
@@ -28,13 +28,17 @@ class GradeGauge extends GaugePainter {
 
     g.setFont(gaugeFont.deriveFont(Font.BOLD, (h * 3 / 16).toFloat))
 
-    // draw current grade
-    val gradeText = f"${input.current}%2.1f%%"
-    textWidthShadow(g, gradeText, w / 4 + 5, h / 2 - 10)
+    if (input.current.isDefined) {
+      // draw current grade
+      val gradeText = f"${input.current.get}%2.1f%%"
+      textWidthShadow(g, gradeText, w / 4 + 5, h / 2 - 10)
+    }
 
-    // draw current grade
-    val eleText = f"${elevation.current}% 4.0f m"
-    textWidthShadow(g, eleText, 0, h * 3 / 4 + 10)
+    if (elevation.current.isDefined) {
+      // draw current elevation
+      val eleText = f"${elevation.current.get}% 4.0f m"
+      textWidthShadow(g, eleText, 0, h * 3 / 4 + 10)
+    }
 
   }
 }

--- a/src/main/scala/peregin/gpv/gui/gauge/LinearElevationGauge.scala
+++ b/src/main/scala/peregin/gpv/gui/gauge/LinearElevationGauge.scala
@@ -8,7 +8,7 @@ import MinMax.RoundedDouble
 
 class LinearElevationGauge extends GaugePainter {
 
-  lazy val dummy = InputValue(728, MinMax(592, 1718))
+  lazy val dummy = InputValue(Some(728), MinMax(592, 1718))
   override def defaultInput = dummy
   override def sample(sonda: Sonda): Unit = input = sonda.elevation
 
@@ -26,18 +26,21 @@ class LinearElevationGauge extends GaugePainter {
     val cy = (h - boxHeight) / 2
     g.fillRect(cx, cy, boxWidth, boxHeight)
 
-    // draw current altitude
-    g.setColor(colorBasedOnInput)
     val ticks = input.boundary.hundredths
-    val vy = ((input.current - input.boundary.min.roundDownToHundredth) * boxHeight / ticks).toInt
-    g.fillRect(cx + boxWidth / 4, cy + boxHeight - vy, (boxWidth / 1.8).toInt, vy)
+
+    if (input.current.isDefined) {
+      // draw current altitude
+      g.setColor(colorBasedOnInput)
+      val vy = ((input.current.get - input.boundary.min.roundDownToHundredth) * boxHeight / ticks).toInt
+      g.fillRect(cx + boxWidth / 4, cy + boxHeight - vy, (boxWidth / 1.8).toInt, vy)
+    }
 
     // draw the border of the box
     g.setColor(Color.white)
     g.setStroke(new BasicStroke(strokeWidth, BasicStroke.CAP_BUTT, BasicStroke.JOIN_ROUND, 10.0f, null, 0.0f))
     g.drawRect(cx, (h - boxHeight) / 2, boxWidth, boxHeight)
 
-    // draw the the ticks and units
+    // draw the ticks and units
     g.setColor(Color.white)
     val longTickLength = math.max(2, strokeWidth)
     val tickStroke = new BasicStroke(math.max(1, strokeWidth / 20))
@@ -53,15 +56,18 @@ class LinearElevationGauge extends GaugePainter {
     }
 
     // draw current altitude
-    val ry = h / 2
-    g.setFont(gaugeFont.deriveFont(Font.BOLD, boxWidth.toFloat))
-    val text = f"${UnitConverter.elevation(input.current, units)}%1.0f"
-    val tb = g.getFontMetrics.getStringBounds(text, g)
-    textWidthShadow(g, text, (w - tb.getWidth) / 2, ry + tb.getHeight / 2)
-    // draw unit
-    g.setFont(gaugeFont.deriveFont(Font.BOLD, strokeWidth.toFloat))
-    val utext = UnitConverter.elevationUnits(units)
-    val utb = g.getFontMetrics.getStringBounds(utext, g)
-    textWidthShadow(g, utext, (w - utb.getWidth) / 2, ry + tb.getHeight / 2 + utb.getHeight)
+    if (input.current.isDefined) {
+      val ry = h / 2
+      g.setFont(gaugeFont.deriveFont(Font.BOLD, boxWidth.toFloat))
+      val text = f"${UnitConverter.elevation(input.current.get, units)}%1.0f"
+      val tb = g.getFontMetrics.getStringBounds(text, g)
+      textWidthShadow(g, text, (w - tb.getWidth) / 2, ry + tb.getHeight / 2)
+
+      // draw unit
+      g.setFont(gaugeFont.deriveFont(Font.BOLD, strokeWidth.toFloat))
+      val utext = UnitConverter.elevationUnits(units)
+      val utb = g.getFontMetrics.getStringBounds(utext, g)
+      textWidthShadow(g, utext, (w - utb.getWidth) / 2, ry + tb.getHeight / 2 + utb.getHeight)
+    }
   }
 }

--- a/src/main/scala/peregin/gpv/gui/gauge/RadialAzimuthGauge.scala
+++ b/src/main/scala/peregin/gpv/gui/gauge/RadialAzimuthGauge.scala
@@ -9,7 +9,7 @@ import peregin.gpv.util.Trigo._
 
 class RadialAzimuthGauge extends GaugePainter {
 
-  lazy val dummy: InputValue = InputValue(27.81, MinMax.max(360))
+  lazy val dummy: InputValue = InputValue(Some(27.81), MinMax.max(360))
   override def defaultInput: InputValue = dummy
   override def sample(sonda: Sonda): Unit = {input = sonda.bearing}
 
@@ -26,7 +26,7 @@ class RadialAzimuthGauge extends GaugePainter {
     val start = 0
     val extent = 360
     var arc = new Arc2D.Double(x, y, dia, dia, start, extent, Arc2D.OPEN)
-    g.setStroke(new BasicStroke(strokeWidth, BasicStroke.CAP_ROUND, BasicStroke.JOIN_MITER, 10.0f, null, 0.0f))
+    g.setStroke(new BasicStroke(strokeWidth.toFloat, BasicStroke.CAP_ROUND, BasicStroke.JOIN_MITER, 10.0f, null, 0.0f))
     g.setColor(Color.black)
     g.draw(arc)
 
@@ -36,7 +36,7 @@ class RadialAzimuthGauge extends GaugePainter {
     y = (h - dia) / 2
     arc = new Arc2D.Double(x, y, dia, dia, start, extent, Arc2D.OPEN)
     g.setColor(Color.white)
-    val borderStroke = new BasicStroke(math.max(2, strokeWidth / 10))
+    val borderStroke = new BasicStroke(math.max(2, strokeWidth / 10).toFloat)
     g.setStroke(borderStroke)
     g.draw(arc)
 
@@ -48,7 +48,7 @@ class RadialAzimuthGauge extends GaugePainter {
     val ticks = input.boundary.tenths
     val longTickLength = math.max(2, r / 10)
     val smallTickLength = math.max(1, longTickLength / 2)
-    val tickStroke = new BasicStroke(math.max(1, strokeWidth / 20))
+    val tickStroke = new BasicStroke(math.max(1, strokeWidth / 20).toFloat)
     g.setFont(gaugeFont.deriveFont((longTickLength + 2).toFloat))
     val ticksWithNumber = if (input.boundary.max > 180) 30 else if (input.boundary.max > 100) 20 else 10
     for (t <- 0 to ticks) {
@@ -56,7 +56,7 @@ class RadialAzimuthGauge extends GaugePainter {
       val tickLength = if (t % ticksWithNumber == 0) {
         g.setStroke(borderStroke)
 
-        val text = f"${ticks - t}%2.0f"
+        val text = f"${ticks - t}%2d"
         val tb = g.getFontMetrics.getStringBounds(text, g)
         val tw = tb.getWidth / 2
         val th = tb.getHeight / 2
@@ -80,22 +80,25 @@ class RadialAzimuthGauge extends GaugePainter {
     cr -= 1
     g.fillOval(cx - cr, cy - cr, 2 * cr, 2 * cr)
 
-    val pointerAngle = - extent - 90 - start + input.current * extent / input.boundary.tenths
-    val pointer = r - strokeWidth / 1.2
-    val pointerStroke = new BasicStroke(math.max(2, strokeWidth / 5), BasicStroke.CAP_ROUND, BasicStroke.JOIN_MITER, 10.0f, null, 0.0f)
-    g.setStroke(pointerStroke)
-    val px = polarX(cx, pointer, pointerAngle)
-    val py = polarY(cy, pointer, pointerAngle)
-    g.setColor(Color.black)
-    g.drawLine(cx + 1, cy + 1, px + 1, py + 1)
-    g.setColor(Color.yellow)
-    g.drawLine(cx, cy, px, py)
-    
-    // draw current azimuth
-    g.setFont(gaugeFont.deriveFont(Font.BOLD, (longTickLength * 4.7).toFloat))
-    val text = f"${input.current}%3.0f"
-    val tb = g.getFontMetrics.getStringBounds(text, g)
-    textWidthShadow(g, text, (w - tb.getWidth) / 2, cy + box / 2 - tb.getHeight * 1.2)
+    if (input.current.isDefined) {
+      val pointerAngle = -extent - 90 - start + input.current.get * extent / input.boundary.tenths
+      val pointer = r - strokeWidth / 1.2
+      val pointerStroke = new BasicStroke(math.max(2, strokeWidth / 5).toFloat, BasicStroke.CAP_ROUND, BasicStroke.JOIN_MITER, 10.0f, null, 0.0f)
+      g.setStroke(pointerStroke)
+      val px = polarX(cx, pointer, pointerAngle)
+      val py = polarY(cy, pointer, pointerAngle)
+      g.setColor(Color.black)
+      g.drawLine(cx + 1, cy + 1, px + 1, py + 1)
+      g.setColor(Color.yellow)
+      g.drawLine(cx, cy, px, py)
+
+      // draw current azimuth
+      g.setFont(gaugeFont.deriveFont(Font.BOLD, (longTickLength * 4.7).toFloat))
+      val text = f"${input.current.get}%3.0f"
+      val tb = g.getFontMetrics.getStringBounds(text, g)
+      textWidthShadow(g, text, (w - tb.getWidth) / 2, cy + box / 2 - tb.getHeight * 1.2)
+    }
+
     // draw unit
     g.setFont(gaugeFont.deriveFont(Font.BOLD, (longTickLength * 2).toFloat))
 //    val utext = UnitConverter.speedUnits(units)

--- a/src/main/scala/peregin/gpv/gui/gauge/RadialSpeedGauge.scala
+++ b/src/main/scala/peregin/gpv/gui/gauge/RadialSpeedGauge.scala
@@ -9,7 +9,7 @@ import peregin.gpv.util.UnitConverter
 
 class RadialSpeedGauge() extends GaugePainter {
 
-  lazy val dummy: InputValue = InputValue(27.81, MinMax.max(62))
+  lazy val dummy: InputValue = InputValue(Some(27.81), MinMax.max(62))
   override def defaultInput: InputValue = dummy
   override def sample(sonda: Sonda): Unit = {input = sonda.speed}
 
@@ -26,7 +26,7 @@ class RadialSpeedGauge() extends GaugePainter {
     val start = -45
     val extent = 270
     var arc = new Arc2D.Double(x, y, dia, dia, start, extent, Arc2D.OPEN)
-    g.setStroke(new BasicStroke(strokeWidth, BasicStroke.CAP_ROUND, BasicStroke.JOIN_MITER, 10.0f, null, 0.0f))
+    g.setStroke(new BasicStroke(strokeWidth.toFloat, BasicStroke.CAP_ROUND, BasicStroke.JOIN_MITER, 10.0f, null, 0.0f))
     g.setColor(Color.black)
     g.draw(arc)
 
@@ -36,7 +36,7 @@ class RadialSpeedGauge() extends GaugePainter {
     y = (h - dia) / 2
     arc = new Arc2D.Double(x, y, dia, dia, start, extent, Arc2D.OPEN)
     g.setColor(Color.white)
-    val borderStroke = new BasicStroke(math.max(2, strokeWidth / 10))
+    val borderStroke = new BasicStroke(math.max(2, strokeWidth / 10).toFloat)
     g.setStroke(borderStroke)
     g.draw(arc)
 
@@ -48,7 +48,7 @@ class RadialSpeedGauge() extends GaugePainter {
     val ticks = input.boundary.tenths
     val longTickLength = math.max(2, r / 10)
     val smallTickLength = math.max(1, longTickLength / 2)
-    val tickStroke = new BasicStroke(math.max(1, strokeWidth / 20))
+    val tickStroke = new BasicStroke(math.max(1, strokeWidth / 20).toFloat)
     g.setFont(gaugeFont.deriveFont((longTickLength + 2).toFloat))
     val ticksWithNumber = if (input.boundary.max > 180) 30 else if (input.boundary.max > 100) 20 else 10
     for (t <- 0 to ticks) {
@@ -95,22 +95,25 @@ class RadialSpeedGauge() extends GaugePainter {
     cr -= 1
     g.fillOval(cx - cr, cy - cr, 2 * cr, 2 * cr)
 
-    val pointerAngle = - extent - start + input.current * extent / input.boundary.tenths
-    val pointer = r - strokeWidth / 1.2
-    val pointerStroke = new BasicStroke(math.max(2, strokeWidth / 5), BasicStroke.CAP_ROUND, BasicStroke.JOIN_MITER, 10.0f, null, 0.0f)
-    g.setStroke(pointerStroke)
-    val px = polarX(cx, pointer, pointerAngle)
-    val py = polarY(cy, pointer, pointerAngle)
-    g.setColor(Color.black)
-    g.drawLine(cx + 1, cy + 1, px + 1, py + 1)
-    g.setColor(Color.yellow)
-    g.drawLine(cx, cy, px, py)
+    if (input.current.isDefined) {
+      val pointerAngle = -extent - start + input.current.get * extent / input.boundary.tenths
+      val pointer = r - strokeWidth / 1.2
+      val pointerStroke = new BasicStroke(math.max(2, strokeWidth / 5).toFloat, BasicStroke.CAP_ROUND, BasicStroke.JOIN_MITER, 10.0f, null, 0.0f)
+      g.setStroke(pointerStroke)
+      val px = polarX(cx, pointer, pointerAngle)
+      val py = polarY(cy, pointer, pointerAngle)
+      g.setColor(Color.black)
+      g.drawLine(cx + 1, cy + 1, px + 1, py + 1)
+      g.setColor(Color.yellow)
+      g.drawLine(cx, cy, px, py)
 
-    // draw current speed
-    g.setFont(gaugeFont.deriveFont(Font.BOLD, (longTickLength * 4.7).toFloat))
-    val text = f"${UnitConverter.speed(input.current, units)}%2.1f"
-    val tb = g.getFontMetrics.getStringBounds(text, g)
-    textWidthShadow(g, text, (w - tb.getWidth) / 2, cy + box / 2 - tb.getHeight * 1.2)
+      // draw current speed
+      g.setFont(gaugeFont.deriveFont(Font.BOLD, (longTickLength * 4.7).toFloat))
+      val text = f"${UnitConverter.speed(input.current.get, units)}%2.1f"
+      val tb = g.getFontMetrics.getStringBounds(text, g)
+      textWidthShadow(g, text, (w - tb.getWidth) / 2, cy + box / 2 - tb.getHeight * 1.2)
+    }
+
     // draw unit
     g.setFont(gaugeFont.deriveFont(Font.BOLD, (longTickLength * 2).toFloat))
     val utext = UnitConverter.speedUnits(units)

--- a/src/main/scala/peregin/gpv/gui/gauge/SvgDistanceGauge.scala
+++ b/src/main/scala/peregin/gpv/gui/gauge/SvgDistanceGauge.scala
@@ -5,14 +5,14 @@ import peregin.gpv.util.UnitConverter
 
 class SvgDistanceGauge extends SvgGauge {
 
-  lazy val dummy = InputValue(80.21, MinMax(0, 123.4))
+  lazy val dummy = InputValue(Some(80.21), MinMax(0, 123.4))
   override def defaultInput = dummy
 
   override def sample(sonda: Sonda): Unit = input = sonda.distance
 
   override def imagePath = "images/road.svg"
 
-  override def valueText = f"${input.current}%2.1f"
+  override def valueText = input.current.map(v => f"${v}%2.1f").getOrElse("")
 
   override def unitText = UnitConverter.distanceUnits(units)
 }

--- a/src/main/scala/peregin/gpv/gui/gauge/SvgElevationGauge.scala
+++ b/src/main/scala/peregin/gpv/gui/gauge/SvgElevationGauge.scala
@@ -5,14 +5,14 @@ import peregin.gpv.util.UnitConverter
 
 class SvgElevationGauge extends SvgGauge {
 
-  lazy val dummy = InputValue(689, MinMax(432, 1252))
+  lazy val dummy = InputValue(Some(689), MinMax(432, 1252))
   override def defaultInput = dummy
 
   override def sample(sonda: Sonda): Unit = input = sonda.elevation
 
   override def imagePath = "images/mountain.svg"
 
-  override def valueText = f"${input.current}%2.0f"
+  override def valueText = input.current.map(v => f"${v}%2.0f").getOrElse("")
 
   override def unitText = UnitConverter.elevationUnits(units)
 }

--- a/src/main/scala/peregin/gpv/gui/gauge/SvgGauge.scala
+++ b/src/main/scala/peregin/gpv/gui/gauge/SvgGauge.scala
@@ -56,8 +56,10 @@ trait SvgGauge extends GaugePainter {
     g.drawImage(whiteImage, px, py, null)
 
     // fill the heart based on the current value
-    val pointerHeight = (input.current - input.boundary.min) * sy / input.boundary.diff
-    g.clipRect(px, py + sy - pointerHeight.toInt, sx, pointerHeight.toInt)
+    if (input.current.isDefined) {
+      val pointerHeight = (input.current.get - input.boundary.min) * sy / input.boundary.diff
+      g.clipRect(px, py + sy - pointerHeight.toInt, sx, pointerHeight.toInt)
+    }
 
     val grayImage = ImageCache.svgImage(imagePath, sx, sy, 150)
     g.drawImage(grayImage, px, py, null)

--- a/src/main/scala/peregin/gpv/gui/gauge/SvgHeartRateGauge.scala
+++ b/src/main/scala/peregin/gpv/gui/gauge/SvgHeartRateGauge.scala
@@ -4,14 +4,14 @@ import peregin.gpv.model.{InputValue, MinMax, Sonda}
 
 class SvgHeartRateGauge extends SvgGauge {
 
-  lazy val dummy = InputValue(89, MinMax(30, 230))
+  lazy val dummy = InputValue(Some(89), MinMax(30, 230))
   override def defaultInput = dummy
 
-  override def sample(sonda: Sonda): Unit = sonda.heartRate.foreach(input = _)
+  override def sample(sonda: Sonda): Unit = { input = sonda.heartRate }
 
   override def imagePath = "images/heart.svg"
 
-  override def valueText = f"${input.current}%2.0f"
+  override def valueText = input.current.map(v => f"${v}%2.0f").getOrElse("")
 
   override def unitText = "bpm"
 }

--- a/src/main/scala/peregin/gpv/gui/gauge/SvgPowerGauge.scala
+++ b/src/main/scala/peregin/gpv/gui/gauge/SvgPowerGauge.scala
@@ -4,14 +4,14 @@ import peregin.gpv.model.{InputValue, MinMax, Sonda}
 
 class SvgPowerGauge extends SvgGauge {
 
-  lazy val dummy = InputValue(121, MinMax(0, 2000))
+  lazy val dummy = InputValue(Some(121), MinMax(0, 2000))
   override def defaultInput = dummy
 
-  override def sample(sonda: Sonda): Unit = sonda.power.foreach(input = _)
+  override def sample(sonda: Sonda): Unit = { input = sonda.power }
 
   override def imagePath = "images/power.svg"
 
-  override def valueText = f"${input.current}%2.0f"
+  override def valueText = input.current.map(v => f"${v}%2.0f").getOrElse("")
 
   override def unitText = "W"
 }

--- a/src/main/scala/peregin/gpv/gui/gauge/TemperatureGauge.scala
+++ b/src/main/scala/peregin/gpv/gui/gauge/TemperatureGauge.scala
@@ -9,18 +9,20 @@ class TemperatureGauge extends GaugePainter {
 
   override def defaultInput: InputValue = null
   override def sample(sonda: Sonda): Unit = {
-    input = sonda.temperature.orNull
+    input = sonda.temperature
   }
 
   override def paint(g: Graphics2D, devHeight: Int, w: Int, h: Int): Unit = {
     if (input != null) {
       super.paint(g, devHeight, w, h)
 
-      // draw temperature
       g.setFont(gaugeFont.deriveFont(Font.BOLD, (h * 3 / 16).toFloat))
       val textBounds = g.getFontMetrics().getStringBounds(" 99°C", g)
-      val text = f"${input.current}% 2.0f°C"
-      textWidthShadow(g, text, w - textBounds.getWidth, h / 2 - h / 8)
+      if (input.current.isDefined) {
+        // draw temperature
+        val text = f"${input.current.get}% 2.0f°C"
+        textWidthShadow(g, text, w - textBounds.getWidth, h / 2 - h / 8)
+      }
 
       val x = (w - textBounds.getWidth - w / 8 - 5).toInt
 

--- a/src/main/scala/peregin/gpv/model/InputValue.scala
+++ b/src/main/scala/peregin/gpv/model/InputValue.scala
@@ -2,11 +2,11 @@ package peregin.gpv.model
 
 object InputValue {
 
-  def empty = new InputValue(0d, MinMax.empty)
-  def zero = new InputValue(0d, MinMax.zero)
+  def empty = new InputValue(None, MinMax.empty)
+  def zero = new InputValue(Some(0d), MinMax.zero)
 }
 
-case class InputValue(current: Double, boundary: MinMax) {
+case class InputValue(current: Option[Double], boundary: MinMax) {
 
-  def isInTop(percent: Int) = (current - boundary.min) * 100 / boundary.diff > 100 - percent
+  def isInTop(percent: Int) = (current.getOrElse(boundary.min) - boundary.min) * 100 / boundary.diff > 100 - percent
 }

--- a/src/main/scala/peregin/gpv/model/Sonda.scala
+++ b/src/main/scala/peregin/gpv/model/Sonda.scala
@@ -11,18 +11,20 @@ object Sonda {
     new GeoPosition(0, 0),
     InputValue.empty, InputValue.empty,
     InputValue.empty, InputValue.empty, InputValue.empty,
-    None, None, None, None
+    InputValue.empty, InputValue.empty, InputValue.empty, InputValue.empty
   )
 
   def sample(): Sonda = new Sonda(
     time = DateTime.now(), elapsedTime = InputValue.zero,
     location = new GeoPosition(47.366074, 8.541264), // Buerkliplatz, Zurich, Switzerland
-    elevation = InputValue(480, MinMax.max(640)), grade = InputValue.empty,
-    distance = InputValue(4, MinMax.max(12)), speed = InputValue(32, MinMax.max(61)),
-    bearing = InputValue(90, MinMax.max(360)),
-    cadence = Some(InputValue(81, MinMax.max(100))),
-    heartRate = Some(InputValue(110, MinMax.max(160))), power = Some(InputValue(223, MinMax.max(320))),
-    temperature = Some(InputValue(30, MinMax.max(100)))
+    elevation = InputValue(Some(480), MinMax.max(640)), grade = InputValue.empty,
+    distance = InputValue(Some(4), MinMax.max(12)),
+    speed = InputValue(Some(32), MinMax.max(61)),
+    bearing = InputValue(Some(90), MinMax.max(360)),
+    cadence = InputValue(Some(81), MinMax.max(100)),
+    heartRate = InputValue(Some(110), MinMax.max(160)),
+    power = InputValue(Some(223), MinMax.max(320)),
+    temperature = InputValue(Some(30), MinMax.max(100))
   )
 }
 
@@ -30,8 +32,8 @@ case class Sonda(time: DateTime, elapsedTime: InputValue,
                  location: GeoPosition,
                  elevation: InputValue, grade: InputValue,
                  distance: InputValue, speed: InputValue, bearing: InputValue,
-                 cadence: Option[InputValue], heartRate: Option[InputValue], power: Option[InputValue],
-                 temperature: Option[InputValue]) {
+                 cadence: InputValue, heartRate: InputValue, power: InputValue,
+                 temperature: InputValue) {
 
   // just for debugging purposes
   private var trackIndex: Int = 0

--- a/src/main/scala/peregin/gpv/model/TrackPoint.scala
+++ b/src/main/scala/peregin/gpv/model/TrackPoint.scala
@@ -31,7 +31,7 @@ case class TrackPoint(position: GeoPosition,
 
   // total distance in kilometers up to this track point
   var distance = 0d
-  // distance between the previous and current track points
+  // distance between the current and next track points
   var segment = 0d
   // average speed of travelling form the previous to current track point
   var speed = 0d
@@ -54,7 +54,7 @@ case class TrackPoint(position: GeoPosition,
     val distanceElevation = next.distance - firstElevation.distance
     if (distanceElevation > 0) grade = (next.elevation - firstElevation.elevation) / distanceElevation * (100 / 1000.0)
 
-    bearing = bearingTo(next)
+    bearing = if (segment == 0) 0 else bearingTo(next)
   }
 
   // The return value is the distance expressed in kilometers.

--- a/src/test/scala/peregin/gpv/model/InputValueSpec.scala
+++ b/src/test/scala/peregin/gpv/model/InputValueSpec.scala
@@ -6,11 +6,11 @@ class InputValueSpec extends Specification {
 
   "input" should {
     "be in top %" in {
-      InputValue(95, MinMax(0, 100)).isInTop(10) must beTrue
-      InputValue(91, MinMax(0, 100)).isInTop(10) must beTrue
-      InputValue(89, MinMax(0, 100)).isInTop(10) must beFalse
-      InputValue(90, MinMax(-100, 100)).isInTop(25) must beTrue
-      InputValue(40, MinMax(-100, 100)).isInTop(25) must beFalse
+      InputValue(Some(95), MinMax(0, 100)).isInTop(10) must beTrue
+      InputValue(Some(91), MinMax(0, 100)).isInTop(10) must beTrue
+      InputValue(Some(89), MinMax(0, 100)).isInTop(10) must beFalse
+      InputValue(Some(90), MinMax(-100, 100)).isInTop(25) must beTrue
+      InputValue(Some(40), MinMax(-100, 100)).isInTop(25) must beFalse
     }
   }
 }

--- a/src/test/scala/peregin/gpv/model/TelemetryTestUtil.scala
+++ b/src/test/scala/peregin/gpv/model/TelemetryTestUtil.scala
@@ -21,7 +21,7 @@ object TelemetryTestUtil {
   def buildTrack(positions: Double*): Seq[TrackPoint] = {
     val tps: ArrayBuffer[TrackPoint] = new ArrayBuffer[TrackPoint];
     for (i <- 0 until positions.length by 2) {
-      tps.addOne(TrackPoint(new GeoPosition(positions(i + 0), positions(i + 1)), 0, new DateTime(i / 2 * 1000L), GarminExtension.empty))
+      tps.addOne(TrackPoint(new GeoPosition(positions(i + 0), positions(i + 1)), 0, new DateTime(i / 2 * 1000L), GarminExtension(Some(i / 2), Some(i / 2), Some(i / 2), Some(i / 2))))
     }
     tps.toSeq
   }


### PR DESCRIPTION
Follow up on previous PR:
- All data may be missing in `Sonda`
- Anything before and after GPX range is marked as missing.
- Anything inside the track when it's missing for more than 5 seconds is marked as missing.
- Bearing is marked as missing in the first point.

Demo: https://youtu.be/DeTT4mQJMU0